### PR TITLE
feat: add deployment-specific GraphQL endpoints and client management

### DIFF
--- a/DEPLOYMENT_ENDPOINTS.md
+++ b/DEPLOYMENT_ENDPOINTS.md
@@ -1,0 +1,178 @@
+# Deployment-Specific GraphQL Endpoints
+
+This document describes the implementation of unique GraphQL endpoints for each deployment, where each endpoint only serves data from contracts associated with that specific deployment.
+
+## Overview
+
+After creating a deployment, you can now access a unique GraphQL endpoint that only returns data for contracts associated with that deployment. This provides data isolation and allows multiple deployments to coexist with their own independent data views.
+
+## Architecture
+
+### Backend Components
+
+1. **DeploymentContext** (`src/graphql/deployment_context.rs`)
+   - Manages deployment-specific context for GraphQL operations
+   - Filters contract addresses to only include those belonging to the deployment
+   - Provides deployment-specific database access
+
+2. **Deployment-Specific Resolvers** 
+   - `DeploymentEventQueryRoot` - Filters events to deployment contracts only
+   - `DeploymentContractQueryRoot` - Only returns contracts belonging to the deployment
+
+3. **Dynamic Schema Generation** (`src/graphql/deployment_schema.rs`)
+   - Creates deployment-specific GraphQL schemas
+   - Each schema is scoped to a particular deployment's data
+
+4. **Routing & Caching** (`src/deployment_service_handler.rs`)
+   - Handles HTTP routing for deployment endpoints
+   - Caches schemas for performance
+   - Manages deployment endpoint discovery
+
+### Frontend Components
+
+1. **Deployment Client** (`client/src/lib/deployment-client.ts`)
+   - Creates Apollo clients for specific deployments
+   - Manages multiple deployment connections
+   - Provides utilities for endpoint discovery
+
+2. **React Hooks** (`client/src/hooks/useDeploymentClient.ts`)
+   - `useDeploymentEndpoints()` - Fetches available deployments
+   - `useDeploymentClient()` - Gets client for specific deployment
+   - `useDeploymentClientManager()` - Manages multiple clients
+
+3. **UI Components**
+   - `DeploymentSelector` - UI for selecting active deployment
+   - Demo page showing deployment-specific data
+
+## API Endpoints
+
+### Deployment Discovery
+```
+GET /deployments/endpoints
+```
+Returns list of all deployments with their GraphQL endpoints:
+```json
+{
+  "deployments": [
+    {
+      "id": "deployment-123",
+      "name": "My Deployment",
+      "description": "Production deployment",
+      "network": "mainnet",
+      "status": "active",
+      "endpoints": {
+        "graphql": "/deployment/deployment-123/graphql",
+        "graphiql": "/deployment/deployment-123/graphiql", 
+        "websocket": "/deployment/deployment-123/ws"
+      }
+    }
+  ],
+  "total_count": 1
+}
+```
+
+### Deployment-Specific GraphQL
+```
+POST /deployment/{deployment_id}/graphql
+```
+GraphQL endpoint that only returns data for contracts associated with the specified deployment.
+
+### GraphiQL Interface
+```
+GET /deployment/{deployment_id}/graphiql
+```
+Interactive GraphQL explorer scoped to the deployment's data.
+
+## Usage Examples
+
+### Backend: Creating a Deployment
+```bash
+# Create a deployment via GraphQL mutation
+curl -X POST http://localhost:3000/graphql \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": "mutation { createDeployment(input: { name: \"My App\", network: \"mainnet\", contractAddress: \"0x123...\" }) { id name } }"
+  }'
+```
+
+### Frontend: Using Deployment Client
+```typescript
+import { createDeploymentClient, fetchDeploymentEndpoints } from './lib/deployment-client';
+
+// Get available deployments
+const deployments = await fetchDeploymentEndpoints();
+
+// Create client for specific deployment
+const client = createDeploymentClient('deployment-123');
+
+// Query deployment-specific data
+const { data } = await client.query({
+  query: GET_EVENTS,
+  variables: { contractAddress: '0x123...', first: 10 }
+});
+```
+
+### Frontend: React Hook Usage
+```typescript
+import { useDeploymentClientManager } from './hooks/useDeploymentClient';
+
+function MyComponent() {
+  const { activeClient, switchDeployment } = useDeploymentClientManager();
+  
+  // Switch to a deployment
+  switchDeployment('deployment-123');
+  
+  // Use the active client
+  return (
+    <ApolloProvider client={activeClient}>
+      <EventsList />
+    </ApolloProvider>
+  );
+}
+```
+
+## Data Isolation
+
+Each deployment endpoint provides complete data isolation:
+
+1. **Contract Filtering**: Only contracts associated with the deployment are queryable
+2. **Event Filtering**: Only events from deployment contracts are returned  
+3. **Schema Isolation**: Each deployment gets its own GraphQL schema instance
+4. **Independent Caching**: Apollo clients cache data separately per deployment
+
+## Performance Considerations
+
+1. **Schema Caching**: Deployment schemas are cached in memory to avoid rebuilding
+2. **Client Caching**: Frontend manages multiple Apollo clients with separate caches
+3. **Lazy Loading**: Schemas are created on-demand when first accessed
+4. **Connection Pooling**: Database connections are shared across deployments
+
+## Security & Access Control
+
+- Deployments are isolated by ID - no cross-deployment data access
+- Each endpoint validates the deployment exists before serving data
+- GraphQL introspection is available per deployment for development
+- Rate limiting can be applied per deployment endpoint
+
+## Development Workflow
+
+1. **Create Deployment**: Use the main GraphQL endpoint to create a deployment
+2. **Get Endpoint**: Fetch deployment endpoints to get the unique GraphQL URL
+3. **Configure Client**: Point your GraphQL client to the deployment-specific endpoint
+4. **Query Data**: All queries now return only data from that deployment's contracts
+
+## Testing
+
+Visit `/deployment-demo` in the client to see a working example of:
+- Deployment selection UI
+- Dynamic client switching  
+- Deployment-specific data queries
+- GraphiQL integration
+
+## Future Enhancements
+
+- **WebSocket Support**: Deployment-specific subscriptions
+- **Database Isolation**: Separate databases per deployment
+- **Access Control**: Authentication/authorization per deployment
+- **Metrics**: Per-deployment usage analytics
+- **Backup/Restore**: Deployment-specific data management

--- a/client/src/app/deployment-demo/page.tsx
+++ b/client/src/app/deployment-demo/page.tsx
@@ -1,0 +1,220 @@
+'use client';
+
+import React, { useState } from 'react';
+import { ApolloProvider, useQuery } from '@apollo/client';
+import { useDeploymentClientManager } from '../../hooks/useDeploymentClient';
+import DeploymentSelector from '../../components/DeploymentSelector';
+import { GET_EVENTS, GET_CONTRACT } from '../../lib/graphql/queries';
+
+// Component to display events from the selected deployment
+function DeploymentEvents() {
+  const { activeClient, activeDeploymentId } = useDeploymentClientManager();
+  const [contractAddress, setContractAddress] = useState(
+    '0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7'
+  );
+
+  if (!activeClient || !activeDeploymentId) {
+    return (
+      <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+        <p className="text-gray-600">Select a deployment to view events</p>
+      </div>
+    );
+  }
+
+  return (
+    <ApolloProvider client={activeClient}>
+      <div className="space-y-4">
+        <div className="flex items-center gap-4">
+          <label htmlFor="contract-address" className="text-sm font-medium text-gray-700">
+            Contract Address:
+          </label>
+          <input
+            id="contract-address"
+            type="text"
+            value={contractAddress}
+            onChange={(e) => setContractAddress(e.target.value)}
+            className="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm"
+            placeholder="Enter contract address"
+          />
+        </div>
+
+        <EventsList contractAddress={contractAddress} />
+      </div>
+    </ApolloProvider>
+  );
+}
+
+// Component to fetch and display events
+function EventsList({ contractAddress }: { contractAddress: string }) {
+  const { data, loading, error } = useQuery(GET_EVENTS, {
+    variables: {
+      contractAddress,
+      first: 20,
+      orderBy: 'BLOCK_NUMBER_DESC',
+    },
+    skip: !contractAddress,
+  });
+
+  if (!contractAddress) {
+    return (
+      <div className="p-4 bg-gray-50 border border-gray-200 rounded-lg">
+        <p className="text-gray-600">Enter a contract address to view events</p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        {[...Array(3)].map((_, i) => (
+          <div key={i} className="p-4 bg-white border border-gray-200 rounded-lg animate-pulse">
+            <div className="h-4 bg-gray-200 rounded w-1/4 mb-2"></div>
+            <div className="h-3 bg-gray-200 rounded w-1/2 mb-2"></div>
+            <div className="h-3 bg-gray-200 rounded w-3/4"></div>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+        <p className="text-red-800 text-sm">Error: {error.message}</p>
+      </div>
+    );
+  }
+
+  const events = data?.events?.edges || [];
+
+  if (events.length === 0) {
+    return (
+      <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+        <p className="text-yellow-800 text-sm">
+          No events found for this contract in the selected deployment.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-lg font-medium text-gray-900">
+        Events ({data.events.totalCount})
+      </h3>
+      
+      {events.map(({ node: event }: any) => (
+        <div key={event.id} className="p-4 bg-white border border-gray-200 rounded-lg">
+          <div className="flex items-center justify-between mb-2">
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-gray-900">{event.eventType}</span>
+              <span className="text-sm text-gray-500">#{event.blockNumber}</span>
+            </div>
+            <span className="text-xs text-gray-500">{event.timestamp}</span>
+          </div>
+          
+          <div className="text-sm text-gray-600 mb-2">
+            <span className="font-medium">Contract:</span> {event.contractAddress}
+          </div>
+          
+          <div className="text-sm text-gray-600 mb-2">
+            <span className="font-medium">Tx Hash:</span> 
+            <span className="font-mono ml-1">{event.transactionHash}</span>
+          </div>
+
+          {event.data && (
+            <div className="mt-3 p-3 bg-gray-50 rounded">
+              <div className="text-sm font-medium text-gray-700 mb-2">Decoded Data:</div>
+              <pre className="text-xs text-gray-600 overflow-x-auto">
+                {JSON.stringify(event.data, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// Component to display contract info
+function ContractInfo({ contractAddress }: { contractAddress: string }) {
+  const { data, loading, error } = useQuery(GET_CONTRACT, {
+    variables: { address: contractAddress },
+    skip: !contractAddress,
+  });
+
+  if (!contractAddress || loading) return null;
+  if (error) return <p className="text-red-600 text-sm">Error loading contract: {error.message}</p>;
+  if (!data?.contract) return <p className="text-gray-600 text-sm">Contract not found</p>;
+
+  return (
+    <div className="p-4 bg-white border border-gray-200 rounded-lg">
+      <h4 className="font-medium text-gray-900 mb-2">Contract Information</h4>
+      <div className="text-sm text-gray-600 space-y-1">
+        <div><span className="font-medium">Address:</span> {data.contract.address}</div>
+        {data.contract.name && (
+          <div><span className="font-medium">Name:</span> {data.contract.name}</div>
+        )}
+        <div><span className="font-medium">Verified:</span> {data.contract.verified ? 'Yes' : 'No'}</div>
+        <div><span className="font-medium">Events:</span> {data.contract.events.length}</div>
+      </div>
+    </div>
+  );
+}
+
+export default function DeploymentDemo() {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <div className="max-w-7xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900">Deployment-Specific GraphQL Demo</h1>
+          <p className="text-gray-600 mt-2">
+            Each deployment provides its own GraphQL endpoint with data specific to that deployment only.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
+          {/* Deployment Selector */}
+          <div className="lg:col-span-1">
+            <div className="bg-white p-6 rounded-lg shadow">
+              <DeploymentSelector />
+            </div>
+          </div>
+
+          {/* Events Display */}
+          <div className="lg:col-span-2">
+            <div className="bg-white p-6 rounded-lg shadow">
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                Deployment Events
+              </h2>
+              <DeploymentEvents />
+            </div>
+          </div>
+        </div>
+
+        {/* Instructions */}
+        <div className="mt-8 bg-white p-6 rounded-lg shadow">
+          <h2 className="text-xl font-semibold text-gray-900 mb-4">How It Works</h2>
+          <div className="prose text-gray-600">
+            <ol className="list-decimal list-inside space-y-2">
+              <li>Each deployment gets its own unique GraphQL endpoint: <code>/deployment/[id]/graphql</code></li>
+              <li>Select a deployment from the list to switch the GraphQL client</li>
+              <li>All queries will then only return data from contracts associated with that deployment</li>
+              <li>Each deployment can have different contracts and different data</li>
+              <li>GraphiQL interfaces are also deployment-specific for easy testing</li>
+            </ol>
+            
+            <div className="mt-4 p-4 bg-blue-50 border border-blue-200 rounded">
+              <h3 className="font-medium text-blue-900">API Endpoints</h3>
+              <ul className="mt-2 space-y-1 text-sm text-blue-800">
+                <li><code>GET /deployments/endpoints</code> - List all deployments</li>
+                <li><code>POST /deployment/[id]/graphql</code> - GraphQL endpoint</li>
+                <li><code>GET /deployment/[id]/graphiql</code> - GraphiQL interface</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/DeploymentSelector.tsx
+++ b/client/src/components/DeploymentSelector.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { useDeploymentEndpoints, useDeploymentClientManager } from '../hooks/useDeploymentClient';
+
+export default function DeploymentSelector() {
+  const { endpoints, loading, error } = useDeploymentEndpoints();
+  const { activeDeploymentId, switchDeployment, clearDeployment } = useDeploymentClientManager();
+
+  if (loading) {
+    return (
+      <div className="p-4 bg-gray-50 rounded-lg">
+        <div className="animate-pulse">
+          <div className="h-4 bg-gray-200 rounded w-1/4 mb-2"></div>
+          <div className="h-8 bg-gray-200 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 bg-red-50 border border-red-200 rounded-lg">
+        <p className="text-red-800 text-sm">Error loading deployments: {error}</p>
+      </div>
+    );
+  }
+
+  if (endpoints.length === 0) {
+    return (
+      <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
+        <p className="text-yellow-800 text-sm">No deployments found. Create a deployment first.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-medium text-gray-900">Select Deployment</h3>
+        {activeDeploymentId && (
+          <button
+            onClick={clearDeployment}
+            className="text-sm text-gray-500 hover:text-gray-700"
+          >
+            Clear Selection
+          </button>
+        )}
+      </div>
+
+      <div className="grid gap-3">
+        {endpoints.map((endpoint) => (
+          <div
+            key={endpoint.id}
+            className={`p-4 border rounded-lg cursor-pointer transition-colors ${
+              activeDeploymentId === endpoint.id
+                ? 'border-blue-500 bg-blue-50'
+                : 'border-gray-200 hover:border-gray-300 hover:bg-gray-50'
+            }`}
+            onClick={() => switchDeployment(endpoint.id)}
+          >
+            <div className="flex items-center justify-between">
+              <div className="flex-1">
+                <div className="flex items-center gap-2">
+                  <h4 className="font-medium text-gray-900">{endpoint.name}</h4>
+                  <span
+                    className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                      endpoint.status === 'active'
+                        ? 'bg-green-100 text-green-800'
+                        : endpoint.status === 'error'
+                        ? 'bg-red-100 text-red-800'
+                        : 'bg-gray-100 text-gray-800'
+                    }`}
+                  >
+                    {endpoint.status}
+                  </span>
+                </div>
+                {endpoint.description && (
+                  <p className="text-sm text-gray-600 mt-1">{endpoint.description}</p>
+                )}
+                <div className="flex items-center gap-4 mt-2 text-xs text-gray-500">
+                  <span>Network: {endpoint.network}</span>
+                  <span>ID: {endpoint.id}</span>
+                </div>
+              </div>
+              
+              {activeDeploymentId === endpoint.id && (
+                <div className="flex items-center gap-2">
+                  <div className="w-2 h-2 bg-blue-500 rounded-full"></div>
+                  <span className="text-sm text-blue-600 font-medium">Active</span>
+                </div>
+              )}
+            </div>
+
+            {/* Quick links */}
+            <div className="flex gap-2 mt-3">
+              <a
+                href={endpoint.endpoints.graphiql}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs text-blue-600 hover:text-blue-800 underline"
+                onClick={(e) => e.stopPropagation()}
+              >
+                GraphiQL
+              </a>
+              <span className="text-xs text-gray-400">•</span>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(endpoint.endpoints.graphql);
+                }}
+                className="text-xs text-gray-600 hover:text-gray-800"
+              >
+                Copy GraphQL URL
+              </button>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {activeDeploymentId && (
+        <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg">
+          <p className="text-sm text-blue-800">
+            <strong>Selected:</strong> {endpoints.find(e => e.id === activeDeploymentId)?.name}
+          </p>
+          <p className="text-xs text-blue-600 mt-1">
+            All GraphQL queries will now use this deployment's data only.
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/src/hooks/useDeploymentClient.ts
+++ b/client/src/hooks/useDeploymentClient.ts
@@ -1,0 +1,91 @@
+import { useState, useEffect, useMemo } from 'react';
+import { ApolloClient } from '@apollo/client';
+import { 
+  DeploymentEndpoint, 
+  fetchDeploymentEndpoints, 
+  createDeploymentClient,
+  DeploymentClientManager 
+} from '../lib/deployment-client';
+
+// Global client manager instance
+const clientManager = new DeploymentClientManager();
+
+/**
+ * Hook to fetch and manage deployment endpoints
+ */
+export function useDeploymentEndpoints(baseUrl?: string) {
+  const [endpoints, setEndpoints] = useState<DeploymentEndpoint[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function loadEndpoints() {
+      try {
+        setLoading(true);
+        setError(null);
+        const deployments = await fetchDeploymentEndpoints(baseUrl);
+        setEndpoints(deployments);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Failed to load deployments');
+      } finally {
+        setLoading(false);
+      }
+    }
+
+    loadEndpoints();
+  }, [baseUrl]);
+
+  return { endpoints, loading, error, refetch: () => loadEndpoints() };
+}
+
+/**
+ * Hook to get a deployment-specific Apollo client
+ */
+export function useDeploymentClient(deploymentId: string | null, baseUrl?: string) {
+  const client = useMemo(() => {
+    if (!deploymentId) return null;
+    return clientManager.getClient(deploymentId);
+  }, [deploymentId]);
+
+  return client;
+}
+
+/**
+ * Hook to manage multiple deployment clients
+ */
+export function useDeploymentClientManager() {
+  const [activeDeploymentId, setActiveDeploymentId] = useState<string | null>(null);
+
+  const switchDeployment = (deploymentId: string) => {
+    setActiveDeploymentId(deploymentId);
+  };
+
+  const clearDeployment = () => {
+    setActiveDeploymentId(null);
+  };
+
+  const getClient = (deploymentId: string) => {
+    return clientManager.getClient(deploymentId);
+  };
+
+  const removeClient = (deploymentId: string) => {
+    clientManager.removeClient(deploymentId);
+    if (activeDeploymentId === deploymentId) {
+      setActiveDeploymentId(null);
+    }
+  };
+
+  const activeClient = useMemo(() => {
+    return activeDeploymentId ? clientManager.getClient(activeDeploymentId) : null;
+  }, [activeDeploymentId]);
+
+  return {
+    activeDeploymentId,
+    activeClient,
+    switchDeployment,
+    clearDeployment,
+    getClient,
+    removeClient,
+    cachedDeploymentIds: clientManager.getCachedDeploymentIds(),
+  };
+}

--- a/client/src/lib/deployment-client.ts
+++ b/client/src/lib/deployment-client.ts
@@ -1,0 +1,141 @@
+import { ApolloClient, InMemoryCache, createHttpLink, from } from '@apollo/client';
+import { setContext } from '@apollo/client/link/context';
+
+export interface DeploymentEndpoint {
+  id: string;
+  name: string;
+  description?: string;
+  network: string;
+  status: string;
+  endpoints: {
+    graphql: string;
+    graphiql: string;
+    websocket: string;
+  };
+}
+
+/**
+ * Creates an Apollo Client for a specific deployment
+ * @param deploymentId - The deployment ID
+ * @param baseUrl - The base URL of the indexer service (default: http://localhost:3000)
+ * @returns Apollo Client instance configured for the deployment
+ */
+export function createDeploymentClient(deploymentId: string, baseUrl: string = 'http://localhost:3000') {
+  const httpLink = createHttpLink({
+    uri: `${baseUrl}/deployment/${deploymentId}/graphql`,
+  });
+
+  // Add deployment context to headers
+  const contextLink = setContext((_, { headers }) => {
+    return {
+      headers: {
+        ...headers,
+        'x-deployment-id': deploymentId,
+      }
+    };
+  });
+
+  return new ApolloClient({
+    link: from([contextLink, httpLink]),
+    cache: new InMemoryCache(),
+    defaultOptions: {
+      watchQuery: {
+        errorPolicy: 'all',
+      },
+      query: {
+        errorPolicy: 'all',
+      },
+    },
+  });
+}
+
+/**
+ * Fetches the list of available deployment endpoints
+ * @param baseUrl - The base URL of the indexer service
+ * @returns Promise<DeploymentEndpoint[]>
+ */
+export async function fetchDeploymentEndpoints(baseUrl: string = 'http://localhost:3000'): Promise<DeploymentEndpoint[]> {
+  try {
+    const response = await fetch(`${baseUrl}/deployments/endpoints`);
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    const data = await response.json();
+    return data.deployments || [];
+  } catch (error) {
+    console.error('Failed to fetch deployment endpoints:', error);
+    return [];
+  }
+}
+
+/**
+ * Creates a deployment-specific GraphiQL URL
+ * @param deploymentId - The deployment ID
+ * @param baseUrl - The base URL of the indexer service
+ * @returns GraphiQL URL for the deployment
+ */
+export function getDeploymentGraphiQLUrl(deploymentId: string, baseUrl: string = 'http://localhost:3000'): string {
+  return `${baseUrl}/deployment/${deploymentId}/graphiql`;
+}
+
+/**
+ * Creates a deployment-specific WebSocket URL for subscriptions
+ * @param deploymentId - The deployment ID
+ * @param baseUrl - The base URL of the indexer service
+ * @returns WebSocket URL for the deployment
+ */
+export function getDeploymentWebSocketUrl(deploymentId: string, baseUrl: string = 'http://localhost:3000'): string {
+  const wsUrl = baseUrl.replace(/^https?/, 'ws');
+  return `${wsUrl}/deployment/${deploymentId}/ws`;
+}
+
+/**
+ * Multi-deployment client manager
+ */
+export class DeploymentClientManager {
+  private clients: Map<string, ApolloClient<any>> = new Map();
+  private baseUrl: string;
+
+  constructor(baseUrl: string = 'http://localhost:3000') {
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * Gets or creates a client for a specific deployment
+   */
+  getClient(deploymentId: string): ApolloClient<any> {
+    if (!this.clients.has(deploymentId)) {
+      const client = createDeploymentClient(deploymentId, this.baseUrl);
+      this.clients.set(deploymentId, client);
+    }
+    return this.clients.get(deploymentId)!;
+  }
+
+  /**
+   * Removes a client from the cache
+   */
+  removeClient(deploymentId: string): void {
+    const client = this.clients.get(deploymentId);
+    if (client) {
+      client.stop();
+      this.clients.delete(deploymentId);
+    }
+  }
+
+  /**
+   * Clears all cached clients
+   */
+  clearAll(): void {
+    for (const client of this.clients.values()) {
+      client.stop();
+    }
+    this.clients.clear();
+  }
+
+  /**
+   * Gets all cached deployment IDs
+   */
+  getCachedDeploymentIds(): string[] {
+    return Array.from(this.clients.keys());
+  }
+}

--- a/src/deployment_service_handler.rs
+++ b/src/deployment_service_handler.rs
@@ -1,0 +1,128 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::Html,
+    Json,
+};
+use async_graphql::http::GraphiQLSource;
+use std::sync::Arc;
+use std::collections::HashMap;
+use tokio::sync::RwLock;
+
+use crate::database::Database;
+use crate::starknet::RpcContext;
+use crate::realtime::RealtimeEventManager;
+use crate::graphql::deployment_context::DeploymentContext;
+use crate::graphql::deployment_schema::{build_deployment_schema, DeploymentSchema};
+
+/// Cache for deployment-specific GraphQL schemas
+pub type SchemaCache = Arc<RwLock<HashMap<String, DeploymentSchema>>>;
+
+/// Create a new schema cache
+pub fn create_schema_cache() -> SchemaCache {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Get or create a deployment-specific GraphQL schema
+pub async fn get_deployment_schema(
+    deployment_id: &str,
+    database: Arc<Database>,
+    rpc: RpcContext,
+    realtime_manager: Arc<RealtimeEventManager>,
+    cache: SchemaCache,
+) -> Result<DeploymentSchema, StatusCode> {
+    // Check cache first
+    {
+        let cache_read = cache.read().await;
+        if let Some(schema) = cache_read.get(deployment_id) {
+            return Ok(schema.clone());
+        }
+    }
+    
+    // Get the deployment from the database
+    let deployment = match database.get_deployment(deployment_id).await {
+        Ok(Some(deployment)) => deployment,
+        Ok(None) => return Err(StatusCode::NOT_FOUND),
+        Err(_) => return Err(StatusCode::INTERNAL_SERVER_ERROR),
+    };
+
+    // Create deployment context
+    let deployment_context = DeploymentContext::new(deployment, database);
+    
+    // Build deployment-specific schema
+    let schema = build_deployment_schema(deployment_context, rpc, realtime_manager);
+    
+    // Cache the schema
+    {
+        let mut cache_write = cache.write().await;
+        cache_write.insert(deployment_id.to_string(), schema.clone());
+    }
+    
+    Ok(schema)
+}
+
+/// Handler for deployment-specific GraphQL queries
+pub async fn deployment_graphql_post_handler(
+    Path(deployment_id): Path<String>,
+    State((database, rpc, realtime_manager, cache)): State<(Arc<Database>, RpcContext, Arc<RealtimeEventManager>, SchemaCache)>,
+    Json(request): Json<serde_json::Value>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let schema = match get_deployment_schema(&deployment_id, database, rpc, realtime_manager, cache).await {
+        Ok(schema) => schema,
+        Err(status) => return Err(status),
+    };
+    
+    // Parse the GraphQL request
+    let graphql_request: async_graphql::Request = match serde_json::from_value(request) {
+        Ok(req) => req,
+        Err(_) => return Err(StatusCode::BAD_REQUEST),
+    };
+    
+    // Execute the GraphQL request
+    let response = schema.execute(graphql_request).await;
+    
+    // Convert response to JSON
+    let json_response = serde_json::to_value(response)
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    Ok(Json(json_response))
+}
+
+/// Handler for deployment-specific GraphiQL interface
+pub async fn deployment_graphiql_handler(
+    Path(deployment_id): Path<String>,
+) -> Html<String> {
+    Html(GraphiQLSource::build()
+        .endpoint(&format!("/deployment/{}/graphql", deployment_id))
+        .subscription_endpoint(&format!("ws://localhost:3000/deployment/{}/ws", deployment_id))
+        .finish())
+}
+
+
+/// Handler to list all deployments with their GraphQL endpoints
+pub async fn list_deployment_endpoints(
+    State((database, _rpc, _realtime_manager, _cache)): State<(Arc<Database>, RpcContext, Arc<RealtimeEventManager>, SchemaCache)>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let deployments = database.get_deployments(None, None, 100, 0).await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    
+    let endpoints: Vec<serde_json::Value> = deployments.into_iter().map(|deployment| {
+        serde_json::json!({
+            "id": deployment.id,
+            "name": deployment.name,
+            "description": deployment.description,
+            "network": deployment.network,
+            "status": deployment.status,
+            "endpoints": {
+                "graphql": format!("/deployment/{}/graphql", deployment.id),
+                "graphiql": format!("/deployment/{}/graphiql", deployment.id),
+                "websocket": format!("/deployment/{}/ws", deployment.id)
+            }
+        })
+    }).collect();
+    
+    Ok(Json(serde_json::json!({
+        "deployments": endpoints,
+        "total_count": endpoints.len()
+    })))
+}

--- a/src/graphql/deployment_context.rs
+++ b/src/graphql/deployment_context.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+use crate::database::{Database, DeploymentRecord};
+
+/// Context for deployment-specific GraphQL operations
+#[derive(Clone)]
+pub struct DeploymentContext {
+    pub deployment: DeploymentRecord,
+    pub database: Arc<Database>,
+}
+
+impl DeploymentContext {
+    pub fn new(deployment: DeploymentRecord, database: Arc<Database>) -> Self {
+        Self { deployment, database }
+    }
+
+    /// Get all contract addresses associated with this deployment
+    pub async fn get_deployment_contract_addresses(&self) -> Result<Vec<String>, sqlx::Error> {
+        // For now, if the deployment has a specific contract address, return that
+        // Otherwise, return all contract addresses (this can be enhanced later)
+        if let Some(contract_address) = &self.deployment.contract_address {
+            Ok(vec![contract_address.clone()])
+        } else {
+            // Get all contract addresses from the database
+            self.database.get_all_contract_addresses().await
+        }
+    }
+
+    /// Check if a contract address belongs to this deployment
+    pub async fn is_contract_in_deployment(&self, contract_address: &str) -> Result<bool, sqlx::Error> {
+        let deployment_addresses = self.get_deployment_contract_addresses().await?;
+        let normalized_address = Database::normalize_address(contract_address);
+        Ok(deployment_addresses.contains(&normalized_address))
+    }
+
+    /// Get deployment-specific database connection
+    /// This allows for future enhancement where each deployment could have its own database
+    pub fn get_database(&self) -> Arc<Database> {
+        // For now, use the main database, but in the future this could connect to deployment-specific databases
+        self.database.clone()
+    }
+}

--- a/src/graphql/deployment_schema.rs
+++ b/src/graphql/deployment_schema.rs
@@ -1,0 +1,32 @@
+use async_graphql::{MergedObject, Schema};
+use std::sync::Arc;
+use crate::graphql::deployment_context::DeploymentContext;
+use crate::graphql::resolvers::deployment_events::DeploymentEventQueryRoot;
+use crate::graphql::resolvers::deployment_contracts::DeploymentContractQueryRoot;
+use crate::graphql::resolvers::subscriptions::SubscriptionRoot;
+use crate::starknet::RpcContext;
+use crate::realtime::RealtimeEventManager;
+
+/// Deployment-specific query root that merges all deployment-specific resolvers
+#[derive(MergedObject, Default)]
+pub struct DeploymentQueryRoot(DeploymentEventQueryRoot, DeploymentContractQueryRoot);
+
+/// Deployment-specific GraphQL schema type
+pub type DeploymentSchema = Schema<DeploymentQueryRoot, async_graphql::EmptyMutation, SubscriptionRoot>;
+
+/// Build a deployment-specific GraphQL schema
+pub fn build_deployment_schema(
+    deployment_context: DeploymentContext,
+    rpc: RpcContext,
+    realtime_manager: Arc<RealtimeEventManager>
+) -> DeploymentSchema {
+    Schema::build(
+        DeploymentQueryRoot::default(),
+        async_graphql::EmptyMutation,
+        SubscriptionRoot
+    )
+    .data(deployment_context)
+    .data(rpc)
+    .data(realtime_manager)
+    .finish()
+}

--- a/src/graphql/mod.rs
+++ b/src/graphql/mod.rs
@@ -1,4 +1,6 @@
 pub mod schema;
 pub mod types;
 pub mod resolvers;
+pub mod deployment_context;
+pub mod deployment_schema;
 

--- a/src/graphql/resolvers/deployment_contracts.rs
+++ b/src/graphql/resolvers/deployment_contracts.rs
@@ -1,0 +1,148 @@
+use async_graphql::{Context, Object, Result as GqlResult};
+use serde_json::Value;
+
+use crate::graphql::types::{Contract, EventSchema, EventInput};
+use crate::graphql::deployment_context::DeploymentContext;
+use crate::starknet::{get_contract_abi_string, RpcContext};
+
+/// Deployment-specific contract query root
+#[derive(Default)]
+pub struct DeploymentContractQueryRoot;
+
+#[Object]
+impl DeploymentContractQueryRoot {
+    /// Get a contract by address (only if it belongs to this deployment)
+    async fn contract(&self, ctx: &Context<'_>, address: String) -> GqlResult<Option<Contract>> {
+        let deployment_context = ctx.data::<DeploymentContext>()?;
+        let rpc = ctx.data::<RpcContext>()?.clone();
+        
+        // Check if this contract belongs to the deployment
+        if !deployment_context.is_contract_in_deployment(&address).await
+            .map_err(|e| format!("Failed to check contract ownership: {}", e))? {
+            return Ok(None);
+        }
+
+        let abi_str = match get_contract_abi_string(&rpc, &address).await {
+            Ok(s) => s,
+            Err(_) => return Ok(None),
+        };
+        
+        let abi_val: Value = serde_json::from_str(&abi_str).unwrap_or(Value::Array(vec![]));
+        let events = parse_event_schemas(&abi_val);
+        
+        Ok(Some(Contract {
+            address,
+            abi: Some(abi_str),
+            events,
+            name: None,
+            verified: true,
+        }))
+    }
+
+    /// Get all contracts for this deployment
+    async fn contracts(&self, ctx: &Context<'_>) -> GqlResult<Vec<Contract>> {
+        let deployment_context = ctx.data::<DeploymentContext>()?;
+        let rpc = ctx.data::<RpcContext>()?.clone();
+        let database = deployment_context.get_database();
+        
+        // Get contract addresses for this deployment
+        let addresses = deployment_context.get_deployment_contract_addresses().await
+            .map_err(|e| format!("Failed to get deployment contracts: {}", e))?;
+        
+        let mut contracts = Vec::new();
+        
+        for addr in addresses {
+            // Get contract stats from database
+            let stats = database.get_indexer_stats(&addr).await
+                .map_err(|e| format!("Database error for {}: {}", addr, e))?;
+            
+            // Try to get ABI and events
+            let (abi_str, events) = match get_contract_abi_string(&rpc, &addr).await {
+                Ok(abi) => {
+                    let abi_val: Value = serde_json::from_str(&abi).unwrap_or(Value::Array(vec![]));
+                    let events = parse_event_schemas(&abi_val);
+                    (Some(abi), events)
+                },
+                Err(_) => (None, vec![])
+            };
+            
+            // Extract contract name from stats or use a default
+            let name = stats.get("contract_name")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            
+            let verified = abi_str.is_some();
+            contracts.push(Contract {
+                address: addr,
+                name,
+                abi: abi_str,
+                events,
+                verified,
+            });
+        }
+        
+        Ok(contracts)
+    }
+
+    /// Get deployment information
+    async fn deployment_info(&self, ctx: &Context<'_>) -> GqlResult<DeploymentInfo> {
+        let deployment_context = ctx.data::<DeploymentContext>()?;
+        let database = deployment_context.get_database();
+        
+        let contract_addresses = deployment_context.get_deployment_contract_addresses().await
+            .map_err(|e| format!("Failed to get deployment contracts: {}", e))?;
+            
+        let mut total_events = 0i64;
+        for addr in &contract_addresses {
+            let count = database.count_events(addr, None).await
+                .map_err(|e| format!("Failed to count events for {}: {}", addr, e))?;
+            total_events += count;
+        }
+        
+        Ok(DeploymentInfo {
+            id: deployment_context.deployment.id.clone(),
+            name: deployment_context.deployment.name.clone(),
+            description: deployment_context.deployment.description.clone(),
+            network: deployment_context.deployment.network.clone(),
+            contract_count: contract_addresses.len() as i32,
+            total_events: total_events as i32,
+            status: deployment_context.deployment.status.clone(),
+            created_at: deployment_context.deployment.created_at.to_rfc3339(),
+        })
+    }
+}
+
+/// Deployment information type
+#[derive(async_graphql::SimpleObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct DeploymentInfo {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub network: String,
+    pub contract_count: i32,
+    pub total_events: i32,
+    pub status: String,
+    pub created_at: String,
+}
+
+fn parse_event_schemas(abi: &Value) -> Vec<EventSchema> {
+    let mut result = Vec::new();
+    if let Some(arr) = abi.as_array() {
+        for item in arr {
+            if item.get("type").and_then(|v| v.as_str()) == Some("event") {
+                let name = item.get("name").and_then(|v| v.as_str()).unwrap_or("").split("::").last().unwrap_or("").to_string();
+                let inputs: Vec<EventInput> = item
+                    .get("members")
+                    .and_then(|m| m.as_array())
+                    .map(|a| a.iter().map(|m| EventInput {
+                        name: m.get("name").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                        r#type: m.get("type").and_then(|v| v.as_str()).unwrap_or("").to_string(),
+                        indexed: m.get("kind").and_then(|v| v.as_str()).map(|k| k == "key").unwrap_or(false),
+                    }).collect()).unwrap_or_default();
+                result.push(EventSchema { name, r#type: "event".to_string(), inputs, anonymous: false });
+            }
+        }
+    }
+    result
+}

--- a/src/graphql/resolvers/deployment_events.rs
+++ b/src/graphql/resolvers/deployment_events.rs
@@ -1,0 +1,195 @@
+use async_graphql::{Context, Object, Result as GqlResult, InputObject};
+
+use crate::database::EventRecord;
+use crate::graphql::types::{Event, EventConnection, EventEdge, PageInfo, EventOrderBy};
+use crate::graphql::deployment_context::DeploymentContext;
+
+/// Input type for deployment-specific event queries
+#[derive(InputObject)]
+#[graphql(rename_fields = "camelCase")]
+pub struct DeploymentEventFilter {
+    pub event_types: Option<Vec<String>>,
+    pub event_keys: Option<Vec<String>>,
+    pub from_block: Option<String>,
+    pub to_block: Option<String>,
+    pub from_timestamp: Option<String>,
+    pub to_timestamp: Option<String>,
+    pub transaction_hash: Option<String>,
+}
+
+/// Deployment-specific event query root
+#[derive(Default)]
+pub struct DeploymentEventQueryRoot;
+
+#[Object]
+impl DeploymentEventQueryRoot {
+    /// Get events for this specific deployment
+    async fn events(
+        &self,
+        ctx: &Context<'_>,
+        filter: Option<DeploymentEventFilter>,
+        first: Option<i32>,
+        after: Option<String>,
+        order_by: Option<EventOrderBy>,
+    ) -> GqlResult<EventConnection> {
+        let deployment_context = ctx.data::<DeploymentContext>()?;
+        let database = deployment_context.get_database();
+        
+        // Get all contract addresses for this deployment
+        let contract_addresses = deployment_context.get_deployment_contract_addresses().await
+            .map_err(|e| format!("Failed to get deployment contracts: {}", e))?;
+            
+        if contract_addresses.is_empty() {
+            return Ok(EventConnection {
+                edges: vec![],
+                page_info: PageInfo {
+                    has_next_page: false,
+                    has_previous_page: false,
+                    start_cursor: None,
+                    end_cursor: None,
+                },
+                total_count: 0,
+            });
+        }
+
+        let limit = first.unwrap_or(20).min(100);
+        let offset = after.as_ref()
+            .and_then(|cursor| cursor.parse::<i32>().ok())
+            .unwrap_or(0);
+
+        // Parse filters
+        let (event_types, event_keys, from_block, to_block, from_timestamp, to_timestamp, transaction_hash) = 
+            if let Some(f) = &filter {
+                (
+                    f.event_types.as_deref(),
+                    f.event_keys.as_deref(),
+                    f.from_block.as_deref().and_then(|s| s.parse().ok()),
+                    f.to_block.as_deref().and_then(|s| s.parse().ok()),
+                    f.from_timestamp.as_deref().and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok()).map(|dt| dt.with_timezone(&chrono::Utc)),
+                    f.to_timestamp.as_deref().and_then(|s| chrono::DateTime::parse_from_rfc3339(s).ok()).map(|dt| dt.with_timezone(&chrono::Utc)),
+                    f.transaction_hash.as_deref(),
+                )
+            } else {
+                (None, None, None, None, None, None, None)
+            };
+
+        // Get events from all contracts in this deployment
+        let mut all_events = Vec::new();
+        let mut total_count = 0;
+
+        for contract_address in &contract_addresses {
+            let events = database.get_events_with_advanced_filters(
+                contract_address,
+                event_types,
+                event_keys,
+                from_block,
+                to_block,
+                from_timestamp,
+                to_timestamp,
+                transaction_hash,
+                limit + 1, // Get one extra to check for next page
+                offset,
+                order_by,
+            ).await.map_err(|e| format!("Failed to fetch events: {}", e))?;
+
+            let count = database.count_events(contract_address, event_types).await
+                .map_err(|e| format!("Failed to count events: {}", e))?;
+
+            all_events.extend(events);
+            total_count += count;
+        }
+
+        // Sort all events by block number and log index (newest first by default)
+        all_events.sort_by(|a, b| match order_by.unwrap_or(EventOrderBy::BlockNumberDesc) {
+            EventOrderBy::BlockNumberDesc => b.block_number.cmp(&a.block_number)
+                .then(b.log_index.cmp(&a.log_index)),
+            EventOrderBy::BlockNumberAsc => a.block_number.cmp(&b.block_number)
+                .then(a.log_index.cmp(&b.log_index)),
+            EventOrderBy::TimestampDesc => b.timestamp.cmp(&a.timestamp)
+                .then(b.log_index.cmp(&a.log_index)),
+            EventOrderBy::TimestampAsc => a.timestamp.cmp(&b.timestamp)
+                .then(a.log_index.cmp(&b.log_index)),
+        });
+
+        let has_next_page = all_events.len() > limit as usize;
+        let events: Vec<EventRecord> = all_events.into_iter().take(limit as usize).collect();
+
+        let edges: Vec<EventEdge> = events
+            .into_iter()
+            .enumerate()
+            .map(|(index, record)| {
+                let cursor = (offset + index as i32).to_string();
+                EventEdge {
+                    node: convert_event_record_to_graphql(record),
+                    cursor: cursor.clone(),
+                }
+            })
+            .collect();
+
+        let page_info = PageInfo {
+            has_next_page,
+            has_previous_page: offset > 0,
+            start_cursor: edges.first().map(|e| e.cursor.clone()),
+            end_cursor: edges.last().map(|e| e.cursor.clone()),
+        };
+
+        Ok(EventConnection {
+            edges,
+            page_info,
+            total_count: total_count as i32,
+        })
+    }
+
+    /// Get a single event by ID (only if it belongs to this deployment)
+    async fn event(&self, ctx: &Context<'_>, id: String) -> GqlResult<Option<Event>> {
+        let deployment_context = ctx.data::<DeploymentContext>()?;
+        let database = deployment_context.get_database();
+        
+        // Parse the event ID to extract contract address and check if it belongs to this deployment
+        // Event IDs are typically in format: contract_address:block_number:transaction_hash:log_index
+        let parts: Vec<&str> = id.split(':').collect();
+        if parts.len() < 2 {
+            return Ok(None);
+        }
+        
+        let contract_address = parts[0];
+        
+        // Check if this contract belongs to the deployment
+        if !deployment_context.is_contract_in_deployment(contract_address).await
+            .map_err(|e| format!("Failed to check contract ownership: {}", e))? {
+            return Ok(None);
+        }
+
+        // Get all events for this contract and find the one with matching ID
+        let events = database.get_events(contract_address, None, None, None, 1000, 0).await
+            .map_err(|e| format!("Failed to fetch events: {}", e))?;
+            
+        for event in events {
+            if event.id == id {
+                return Ok(Some(convert_event_record_to_graphql(event)));
+            }
+        }
+        
+        Ok(None)
+    }
+}
+
+/// Helper function to convert database record to GraphQL type
+fn convert_event_record_to_graphql(record: EventRecord) -> Event {
+    let data = record.decoded_data.and_then(|d| serde_json::from_str(&d).ok());
+    let raw_data: Vec<String> = serde_json::from_str(&record.raw_data).unwrap_or_default();
+    let raw_keys: Vec<String> = serde_json::from_str(&record.raw_keys).unwrap_or_default();
+
+    Event {
+        id: record.id,
+        contract_address: record.contract_address,
+        event_type: record.event_type,
+        block_number: record.block_number.to_string(),
+        transaction_hash: record.transaction_hash,
+        log_index: record.log_index,
+        timestamp: record.timestamp.to_rfc3339(),
+        data,
+        raw_data,
+        raw_keys,
+    }
+}

--- a/src/graphql/resolvers/mod.rs
+++ b/src/graphql/resolvers/mod.rs
@@ -2,4 +2,6 @@ pub mod events;
 pub mod contracts;
 pub mod subscriptions;
 pub mod deployments;
+pub mod deployment_events;
+pub mod deployment_contracts;
 


### PR DESCRIPTION
- Introduced a new document detailing deployment-specific GraphQL endpoints for data isolation.
- Implemented backend components for managing deployment contexts and dynamic schema generation.
- Developed frontend components including a deployment selector and demo page for interacting with deployment-specific data.
- Added hooks for managing deployment clients and fetching deployment endpoints.
- Enhanced GraphQL resolvers to support deployment-specific queries for contracts and events.
- Updated routing in the main application to handle deployment-related requests.
closes: #36 